### PR TITLE
fix sorting in utils for larger arrays

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ utils.sortAndUnique = function(arr) {
   });
 
   return result.sort(function(a, b) {
-    return a - b > 0;
+    return a - b;
   });
 };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -46,4 +46,10 @@ describe('utils', function() {
     arr = [87, 0, 2, 13, 87, 9, 1, 9, 10];
     should(utils.sortAndUnique(arr)).eql([0, 1, 2, 9, 10, 13, 87]);
   });
+
+  it('Sorting larger arrays', function() {
+    var arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    should(utils.sortAndUnique(arr)).eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+  });
 });


### PR DESCRIPTION
Fixes a bug when using arrays larger than 10 elements long. When using smaller arrays, insertion sort is used and the bug does not present itself. However, when using larger arrays, a simple test shows that the sorting function does not work. The bug is due to error in the compare function: the function should return a negative, positive or 0 number, but currently only returns true or false.
